### PR TITLE
Fix flaky build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - sh -e /etc/init.d/xvfb start
   - wget -q -t 3 http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar
   - java -jar selenium-server-standalone-2.45.0.jar -log selenium.log &
-  - sleep 3
+  - until $(echo | nc localhost 4444); do sleep 1; echo waiting for selenium-server...; done;
 
 script: ./vendor/bin/phpunit
 


### PR DESCRIPTION
I think sleeping 3 seconds until the server is up and running is just flaky.
Just wait until we can connect to the server, then start the tests.